### PR TITLE
refactor: index.js exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ _bangle-website/.cache-loader
 _bangle-website/docs/api
 
 /dist
+
+.idea

--- a/contrib/markdown-front-matter/index.js
+++ b/contrib/markdown-front-matter/index.js
@@ -1,2 +1,4 @@
-export * as markdownFrontMatter from './markdown-front-matter';
+import * as markdownFrontMatter from './markdown-front-matter';
 export { frontMatterPlugin as frontMatterMarkdownItPlugin } from './markdown-it-plugin';
+
+export { markdownFrontMatter };

--- a/contrib/react-emoji-suggest/index.js
+++ b/contrib/react-emoji-suggest/index.js
@@ -1,2 +1,4 @@
-export * as emojiSuggest from './emoji-suggest';
+import * as emojiSuggest from './emoji-suggest';
+
 export * from './EmojiSuggest';
+export { emojiSuggest };

--- a/contrib/react-sticker/index.js
+++ b/contrib/react-sticker/index.js
@@ -1,2 +1,4 @@
-export * as sticker from './sticker';
-export * as default from './sticker';
+import * as sticker from './sticker';
+
+export { sticker };
+export default sticker;

--- a/contrib/react-stopwatch/index.js
+++ b/contrib/react-stopwatch/index.js
@@ -1,2 +1,4 @@
-export * as stopwatch from './stopwatch';
-export * as default from './stopwatch';
+import * as stopwatch from './stopwatch';
+
+export { stopwatch };
+export default stopwatch;

--- a/contrib/text-formatting/index.js
+++ b/contrib/text-formatting/index.js
@@ -1,2 +1,4 @@
-export * as superscript from './superscript';
-export * as subscript from './subscript';
+import * as superscript from './superscript';
+
+export { superscript };
+export default superscript;

--- a/contrib/timestamp/index.js
+++ b/contrib/timestamp/index.js
@@ -1,1 +1,3 @@
-export * as timestamp from './timestamp';
+import * as timestamp from './timestamp';
+
+export { timestamp };

--- a/contrib/trailing-node/index.js
+++ b/contrib/trailing-node/index.js
@@ -1,1 +1,3 @@
-export * as trailingNode from './trailing-node';
+import * as trailingNode from './trailing-node';
+
+export { trailingNode };

--- a/core/components/index.js
+++ b/core/components/index.js
@@ -1,27 +1,52 @@
 // marks
-export * as bold from './bold';
-export * as code from './code';
-export * as italic from './italic';
-export * as link from './link';
-export * as strike from './strike';
-export * as underline from './underline';
+import * as bold from './bold';
+import * as code from './code';
+import * as italic from './italic';
+import * as link from './link';
+import * as strike from './strike';
+import * as underline from './underline';
 
 // nodes
-export * as doc from './doc';
-export * as paragraph from './paragraph';
-export * as text from './text';
-export * as blockquote from './blockquote';
-export * as bulletList from './bullet-list';
-export * as codeBlock from './code-block';
-export * as hardBreak from './hard-break';
-export * as heading from './heading';
-export * as horizontalRule from './horizontal-rule';
-export * as listItem from './list-item/list-item';
-export * as orderedList from './ordered-list';
-export * as todoItem from './todo-item';
-export * as todoList from './todo-list';
-export * as image from './image';
+import * as doc from './doc';
+import * as paragraph from './paragraph';
+import * as text from './text';
+import * as blockquote from './blockquote';
+import * as bulletList from './bullet-list';
+import * as codeBlock from './code-block';
+import * as hardBreak from './hard-break';
+import * as heading from './heading';
+import * as horizontalRule from './horizontal-rule';
+import * as listItem from './list-item/list-item';
+import * as orderedList from './ordered-list';
+import * as todoItem from './todo-item';
+import * as todoList from './todo-list';
+import * as image from './image';
 
 // components
-export * as history from './history';
-export * as editorStateCounter from './editor-state-counter';
+import * as history from './history';
+import * as editorStateCounter from './editor-state-counter';
+
+export {
+  bold,
+  code,
+  italic,
+  link,
+  strike,
+  underline,
+  doc,
+  paragraph,
+  text,
+  blockquote,
+  bulletList,
+  codeBlock,
+  hardBreak,
+  heading,
+  horizontalRule,
+  listItem,
+  orderedList,
+  todoItem,
+  todoList,
+  image,
+  history,
+  editorStateCounter,
+};

--- a/core/index.js
+++ b/core/index.js
@@ -1,11 +1,11 @@
 import * as logging from './utils/logging';
 import browser, { isChromeWithSelectionBug } from './utils/browser';
-export * as utils from './utils';
+import * as utils from './utils';
+
 export * from './components/index';
 export * from './bangle-editor';
 export * from './bangle-editor-state';
 export * from './node-view';
 export * from './spec-registry';
 export * from './plugin';
-
-export { logging, browser, isChromeWithSelectionBug };
+export { logging, browser, isChromeWithSelectionBug, utils };

--- a/emoji/index.js
+++ b/emoji/index.js
@@ -1,3 +1,5 @@
+import * as emoji from './emoji';
+
 export * from './data';
 export * from './emoji-markdown-it-plugin';
-export * as emoji from './emoji';
+export { emoji };

--- a/react-menu/index.js
+++ b/react-menu/index.js
@@ -1,4 +1,4 @@
-export * as floatingMenu from './floating-menu';
+import * as floatingMenu from './floating-menu';
 export * from './LinkSubMenu';
 export * from './FloatingMenu';
 export * from './Menu';
@@ -8,3 +8,5 @@ export * from './Icons';
 export * from './Icon';
 export * from './MenuButtons';
 export * from './MenuDropdown';
+
+export { floatingMenu };

--- a/tooltip/index.js
+++ b/tooltip/index.js
@@ -1,4 +1,6 @@
+import * as tooltipPlacement from './tooltip-placement';
+import * as selectionTooltip from './selection-tooltip';
+import * as suggestTooltip from './suggest-tooltip';
+
 export * from './create-tooltip-dom';
-export * as tooltipPlacement from './tooltip-placement';
-export * as selectionTooltip from './selection-tooltip';
-export * as suggestTooltip from './suggest-tooltip';
+export { tooltipPlacement, selectionTooltip, suggestTooltip };


### PR DESCRIPTION
This fixes an issue with the latest version of Create React App with Typescrpt, where the app will crash due to unsupported exports with an alias.