### PR TITLE
fix circular dependencies in tooltip

### DIFF
--- a/tooltip/selection-tooltip.js
+++ b/tooltip/selection-tooltip.js
@@ -1,7 +1,7 @@
 import { Plugin, PluginKey } from '@bangle.dev/core/index';
 import { tooltipPlacement } from '@bangle.dev/tooltip/index';
 import { NodeSelection } from '@bangle.dev/core/prosemirror/state';
-import { createTooltipDOM } from './index';
+import { createTooltipDOM } from './create-tooltip-dom';
 
 export const plugins = selectionTooltip;
 export const commands = {
@@ -13,7 +13,7 @@ export const commands = {
 
 const LOG = false;
 
-let log = LOG ? console.log.bind(console, 'selection-tooltip') : () => {};
+let log = LOG ? console.log.bind(console, 'selection-tooltip') : () => { };
 
 function selectionTooltip({
   key = new PluginKey('selectionTooltipPlugin'),

--- a/tooltip/suggest-tooltip.js
+++ b/tooltip/suggest-tooltip.js
@@ -8,11 +8,11 @@ import {
 } from '@bangle.dev/core/utils/pm-utils';
 import { Plugin, PluginKey, isChromeWithSelectionBug } from '@bangle.dev/core';
 
-import { tooltipPlacement } from './index';
+import * as tooltipPlacement from './tooltip-placement';
 import { triggerInputRule } from './trigger-input-rule';
 
 const LOG = false;
-let log = LOG ? console.log.bind(console, 'plugins/suggest-tooltip') : () => {};
+let log = LOG ? console.log.bind(console, 'plugins/suggest-tooltip') : () => { };
 
 export const spec = specFactory;
 export const plugins = pluginsFactory;
@@ -152,14 +152,14 @@ function pluginsFactory({
         key,
       }),
       keybindings &&
-        keymap({
-          [keybindings.select]: (state, dispatch, view) => {
-            return filter(isActiveCheck, onEnter)(state, dispatch, view);
-          },
-          [keybindings.up]: filter(isActiveCheck, onArrowUp),
-          [keybindings.down]: filter(isActiveCheck, onArrowDown),
-          [keybindings.hide]: filter(isActiveCheck, onEscape),
-        }),
+      keymap({
+        [keybindings.select]: (state, dispatch, view) => {
+          return filter(isActiveCheck, onEnter)(state, dispatch, view);
+        },
+        [keybindings.up]: filter(isActiveCheck, onArrowUp),
+        [keybindings.down]: filter(isActiveCheck, onArrowDown),
+        [keybindings.hide]: filter(isActiveCheck, onEscape),
+      }),
     ];
   };
 }
@@ -374,8 +374,8 @@ export function replaceSuggestMarkWith(key, maybeNode) {
           maybeNode instanceof Node || isInputFragment
             ? maybeNode
             : typeof maybeNode === 'string'
-            ? state.schema.text(maybeNode)
-            : Node.fromJSON(state.schema, maybeNode);
+              ? state.schema.text(maybeNode)
+              : Node.fromJSON(state.schema, maybeNode);
       } catch (e) {
         console.error(e);
         return tr;


### PR DESCRIPTION
Noticed some errors when building with webpack 5. the index.js is requiring the files, but then they require other imports through the index.js as well which causes problems. Resolves the errors from issue: https://github.com/bangle-io/bangle.dev/issues/151