### PR TITLE
handle Error.captureStackTrace not available on Safari

### DIFF
--- a/collab/collab-error.js
+++ b/collab/collab-error.js
@@ -3,7 +3,16 @@ export class CollabError extends Error {
     super(body);
     this.errorCode = errorCode;
     this.body = body;
-    Error.captureStackTrace(this, CollabError);
+    // Error.captureStackTrace is a v8-specific method so not avilable on
+    // Firefox or Safari
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CollabError);
+    } else {
+      const stack = new Error().stack;
+      if (stack) {
+        this.stack = stack;
+      }
+    }
     this.name = this.constructor.name;
   }
 }


### PR DESCRIPTION
Fix for #172 