### PR TITLE
fix join heading to prev list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 **NOTE: until we hit v1, expect breaking changes the minor versions (0.x).**
 
+## HEAD
+
+**@bangle.dev/core**
+
+- bug: Fixed a bug that backspacing at the start of heading doesn't work correctly https://github.com/bangle-io/bangle.dev/pull/193
+
 ## 0.13.0
 
 **@bangle.dev/core**

--- a/core/components/__tests__/list-item.test.js
+++ b/core/components/__tests__/list-item.test.js
@@ -1108,6 +1108,36 @@ describe('Pressing Backspace', () => {
     );
   });
 
+  it('should move heading content back to previous (nested) list item', async () => {
+    await check(
+      <doc>
+        <ol>
+          <li>
+            <para>text</para>
+            <ol>
+              <li>
+                <para>text</para>
+              </li>
+            </ol>
+          </li>
+        </ol>
+        <heading level={1}>[]after</heading>
+      </doc>,
+      <doc>
+        <ol>
+          <li>
+            <para>text</para>
+            <ol>
+              <li>
+                <para>text[]after</para>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </doc>,
+    );
+  });
+
   it('keeps nodes same level as backspaced list item together in same list', async () => {
     await check(
       <doc>

--- a/core/components/list-item/commands.js
+++ b/core/components/list-item/commands.js
@@ -744,7 +744,7 @@ function joinToPreviousListItem(type) {
     }
 
     const { $from } = state.selection;
-    const { paragraph, codeBlock, bulletList, orderedList } =
+    const { paragraph, codeBlock, heading, bulletList, orderedList } =
       state.schema.nodes;
     const isGapCursorShown = state.selection instanceof GapCursorSelection;
     const $cutPos = isGapCursorShown ? state.doc.resolve($from.pos + 1) : $from;
@@ -758,10 +758,10 @@ function joinToPreviousListItem(type) {
       $cut.nodeBefore &&
       [bulletList, orderedList].indexOf($cut.nodeBefore.type) > -1
     ) {
-      // and the node after this is a paragraph or a codeBlock
+      // and the node after this is a paragraph / codeBlock / heading
       if (
         $cut.nodeAfter &&
-        ($cut.nodeAfter.type === paragraph || $cut.nodeAfter.type === codeBlock)
+        [paragraph, codeBlock, heading].indexOf($cut.nodeAfter.type) > -1
       ) {
         // find the nearest paragraph that precedes this node
         let $lastNode = $cut.doc.resolve($cut.pos - 1);
@@ -776,7 +776,7 @@ function joinToPreviousListItem(type) {
           if (typeof nodeBeforePos !== 'number') {
             return false;
           }
-          // append the codeblock to the list node
+          // append the paragraph / codeblock / heading to the list node
           const list = $cut.nodeBefore.copy(
             $cut.nodeBefore.content.append(
               Fragment.from(listItem.createChecked({}, $cut.nodeAfter)),
@@ -789,7 +789,7 @@ function joinToPreviousListItem(type) {
           );
         } else {
           // take the text content of the paragraph and insert after the paragraph up until before the the cut
-          tr = state.tr.step(
+          tr = tr.step(
             new ReplaceAroundStep(
               $lastNode.pos,
               $cut.pos + $cut.nodeAfter.nodeSize,


### PR DESCRIPTION
Fix #188

The reason is the `joinToPreviousListItem` function only handles the cases for paragraph and code block.