### PR TITLE
improve marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 **NOTE: until we hit v1, expect breaking changes the minor versions (0.x).**
 
+## 0.28.3
+**@bangle.dev/base-components**
+
+- enhancement: Improved mark input regex.
+
+**@bangle.dev/tooltip**
+
+- enhancement: suggestMark disallows any other mark when it is active.
+
 ## 0.28.2
 **@bangle.dev/core**
 

--- a/components/base-components/__tests__/italic.test.js
+++ b/components/base-components/__tests__/italic.test.js
@@ -3,7 +3,12 @@
  */
 
 /** @jsx psx */
-import { psx, sendKeyToPm, setSelectionNear } from '@bangle.dev/test-helpers';
+import {
+  psx,
+  sendKeyToPm,
+  setSelectionNear,
+  typeText,
+} from '@bangle.dev/test-helpers';
 import { italic } from '../index';
 import { defaultTestEditor } from './test-editor';
 
@@ -58,5 +63,64 @@ describe('Basic', () => {
     setSelectionNear(view, 9);
 
     expect(italic.commands.queryIsItalicActive()(view.state)).toBe(true);
+  });
+});
+
+describe('markdown shortcuts', () => {
+  const testEditor = defaultTestEditor();
+
+  test('_ shortcut', async () => {
+    const { editorView } = testEditor(
+      <doc>
+        <para>first</para>
+        <para>[]</para>
+      </doc>,
+    );
+
+    typeText(editorView, '_magic_');
+    expect(editorView.state).toEqualDocAndSelection(
+      <doc>
+        <para>first</para>
+        <para>
+          <italic>magic</italic>
+        </para>
+      </doc>,
+    );
+  });
+
+  test('_ shortcut after a word', async () => {
+    const { editorView } = testEditor(
+      <doc>
+        <para>first</para>
+        <para>hey there []</para>
+      </doc>,
+    );
+
+    typeText(editorView, '_sweety_');
+    expect(editorView.state).toEqualDocAndSelection(
+      <doc>
+        <para>first</para>
+        <para>
+          hey there <italic>sweety</italic>
+        </para>
+      </doc>,
+    );
+  });
+
+  test('_ shortcut while inside a word', async () => {
+    const { editorView } = testEditor(
+      <doc>
+        <para>first</para>
+        <para>hey there[]</para>
+      </doc>,
+    );
+
+    typeText(editorView, '_omg_');
+    expect(editorView.state).toEqualDocAndSelection(
+      <doc>
+        <para>first</para>
+        <para>hey there_omg_</para>
+      </doc>,
+    );
   });
 });

--- a/components/base-components/bold.ts
+++ b/components/base-components/bold.ts
@@ -73,9 +73,13 @@ function pluginsFactory({
 
     return [
       markdownShortcut &&
-        markPasteRule(/(?:\*\*|__)([^*_]+)(?:\*\*|__)/g, type),
+        markPasteRule(/(?:^|\s)((?:\*\*)((?:[^*]+))(?:\*\*))/g, type),
       markdownShortcut &&
-        markInputRule(/(?:\*\*|__)([^*_]+)(?:\*\*|__)$/, type),
+        markPasteRule(/(?:^|\s)((?:__)((?:[^__]+))(?:__))/g, type),
+      markdownShortcut &&
+        markInputRule(/(?:^|\s)((?:__)((?:[^__]+))(?:__))$/, type),
+      markdownShortcut &&
+        markInputRule(/(?:^|\s)((?:\*\*)((?:[^*]+))(?:\*\*))$/, type),
       keybindings &&
         keymap(createObject([[keybindings.toggleBold, toggleBold()]])),
     ];

--- a/components/base-components/italic.ts
+++ b/components/base-components/italic.ts
@@ -56,8 +56,8 @@ function pluginsFactory({ keybindings = defaultKeys } = {}): RawPlugins {
     return [
       markPasteRule(/_([^_]+)_/g, type),
       markPasteRule(/\*([^*]+)\*/g, type),
-      markInputRule(/(?:^|[^_])(_([^_]+)_)$/, type),
-      markInputRule(/(?:^|[^*])(\*([^*]+)\*)$/, type),
+      markInputRule(/(?:^|\s)((?:_)((?:[^_]+))(?:_))$/, type),
+      markInputRule(/(?:^|\s)((?:\*)((?:[^*]+))(?:\*))$/, type),
       keybindings &&
         keymap(createObject([[keybindings.toggleItalic, toggleMark(type)]])),
     ];

--- a/components/base-components/strike.ts
+++ b/components/base-components/strike.ts
@@ -69,8 +69,8 @@ function pluginsFactory({ keybindings = defaultKeys } = {}): RawPlugins {
     const type = getTypeFromSchema(schema);
 
     return [
-      markPasteRule(/~([^~]+)~/g, type),
-      markInputRule(/~([^~]+)~$/, type),
+      markPasteRule(/(?:^|\s)((?:~~)((?:[^~]+))(?:~~))/g, type),
+      markInputRule(/(?:^|\s)((?:~~)((?:[^~]+))(?:~~))$/, type),
       keybindings &&
         keymap(createObject([[keybindings.toggleStrike, toggleMark(type)]])),
     ];

--- a/components/tooltip/suggest-tooltip.ts
+++ b/components/tooltip/suggest-tooltip.ts
@@ -62,6 +62,7 @@ function specFactory({
     type: 'mark',
     schema: {
       inclusive: true,
+      excludes: '_',
       group: 'suggestTriggerMarks',
       parseDOM: [{ tag: `span[data-${markName}]` }],
       toDOM: (mark) => {


### PR DESCRIPTION
Sourcing tiptaps's improved regex for disallowing creating a mark when inside a word. 