### PR TITLE
fix: allow multiple calls to saveRenderHandlers if the value is identical

### DIFF
--- a/lib/core/src/node-view.ts
+++ b/lib/core/src/node-view.ts
@@ -297,7 +297,10 @@ export function saveRenderHandlers(
   editorContainer: HTMLElement,
   handlers: RenderHandlers,
 ) {
-  if (renderHandlersCache.has(editorContainer)) {
+  if (
+    renderHandlersCache.has(editorContainer) &&
+    renderHandlersCache.get(editorContainer) !== handlers
+  ) {
     throw new Error(
       'It looks like renderHandlers were already set by someone else.',
     );


### PR DESCRIPTION
### Description

Allows the component to function correctly when React.StrictMode is set.

closes #264